### PR TITLE
2 bits is better than 8

### DIFF
--- a/gbcamextract.c
+++ b/gbcamextract.c
@@ -138,8 +138,8 @@ void convert( char frameBuffer[BANK_SIZE * 2], char saveBuffer[BUFFER_SIZE], cha
     {
       // for each span
       spanAddress = tileAddress + spanNum*2;
-      lowBits = frameBuffer[spanAddress];
-      highBits = frameBuffer[++spanAddress];
+      lowBits = saveBuffer[spanAddress];
+      highBits = saveBuffer[++spanAddress];
       x = 16 + xTile*8;
       y = 16 + yTile*8 + spanNum;
 //       printf( "tile: %d, x: %d, y: %d\n", tileNum, x, y );

--- a/gbcamextract.c
+++ b/gbcamextract.c
@@ -225,6 +225,8 @@ void writeImageFile( char pixelBuffer[], int picNum )
 
     // init output
   png_init_io( png_ptr, fp );
+  png_set_compression_level(png_ptr, Z_BEST_COMPRESSION);
+  png_set_compression_mem_level(png_ptr, 9);
 
   // set header info
   png_set_IHDR( png_ptr, info_ptr, WIDTH, HEIGHT, 2,

--- a/gbcamextract.c
+++ b/gbcamextract.c
@@ -1,18 +1,18 @@
 /*
  * gbcamextract.c, extracts photos from Game Boy Camera save files.
- * 
+ *
  * Copyright (c) 2013 jkbenaim. MIT license.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -20,99 +20,101 @@
  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
- * 
+ *
  */
 
 
-#include <stdlib.h>     // malloc
+#include <stdlib.h>     // malloc, EXIT_SUCCESS, EXIT_FAILURE, NULL
 #include <stdio.h>      // printf, fopen, fclose, fread
 #include <string.h>     // strerror
 #include <errno.h>      // errno
 #include <png.h>
 #include <zlib.h>
 
+const int FILE_ERROR = 2;
+const int FILE_SIZE_ERROR = 3;
+
 const int WIDTH = 160;
 const int HEIGHT = 144;
+const int BUFFER_SIZE = 128*1024;
+const int BANK_SIZE = 0x4000;
 
 int picNum2BaseAddress( int picNum );
-void printPicInfo( char buf[static 128*1024], int picNum );
-void convert( char frameBuffer[static 2*16384], char saveBuffer[static 128*1024], char pixelBuffer[static WIDTH*HEIGHT], int picNum );
-void writeImageFile( char pixelBuffer[static WIDTH*HEIGHT], int picNum );
-void drawSpan( char pixelBuffer[static WIDTH*HEIGHT], char lowBits, char highBits, int x, int y );
+void printPicInfo( char buf[BUFFER_SIZE], int picNum );
+void convert( char frameBuffer[BANK_SIZE * 2], char saveBuffer[BUFFER_SIZE], char pixelBuffer[WIDTH*HEIGHT], int picNum );
+void writeImageFile( char pixelBuffer[WIDTH*HEIGHT], int picNum );
+void drawSpan( char pixelBuffer[WIDTH*HEIGHT], char lowBits, char highBits, int x, int y );
 
 int main( int argc, char *argv[] )
-{ 
+{
   // Argument count check
   if( argc < 3 )
   {
     fprintf( stderr, "%s: usage: gbcamextract camerarom.gb save.sav\n", argv[0] );
-    return 1;
+    return EXIT_FAILURE;
   }
-  
-  
+
+
   // Open rom file
   FILE* file = fopen( argv[1], "r" );
   if( file == NULL )
   {
     // Failure while attempting to open the file.
     fprintf( stderr, "%s: cannot open `%s': %s\n", argv[0], argv[1], strerror(errno) );
-    return 2;
+    return FILE_ERROR;
   }
-  
+
   // Read the rom file into memory.
   // This is used to extract the frame data.
-  char frameBuffer[2*16384];   // two banks
+  char frameBuffer[BANK_SIZE * 2];   // two banks
   size_t blocksRead = 0;
   if( !fseek( file, 0xd0000, SEEK_SET ) )       // beginning of bank 34h
-    blocksRead = fread( frameBuffer, 2*16384, 1, file );
+    blocksRead = fread( frameBuffer, BANK_SIZE * 2, 1, file );
   if( blocksRead != 1 )
   {
     // We read the wrong amount of bytes. Bail.
     fprintf( stderr, "%s: cannot open `%s': Wrong file size.\n", argv[0], argv[1] );
-    return 3;
+    return FILE_SIZE_ERROR;
   }
-  
+
   // Close rom file
   fclose( file );
-  
-  
+
+
   // Open save file
   file = fopen( argv[2], "r" );
   if( file == NULL )
   {
     // Failure while attempting to open the file.
     fprintf( stderr, "%s: cannot open `%s': %s\n", argv[0], argv[2], strerror(errno) );
-    return 2;
+    return FILE_ERROR;
   }
-  
+
   // Read the save file into memory
-  char saveBuffer[128*1024];   // 128k son. this is as good as it gets on gameboy
-  blocksRead = fread( saveBuffer, 128*1024, 1, file );
+  char saveBuffer[BUFFER_SIZE];   // 128k son. this is as good as it gets on gameboy
+  blocksRead = fread( saveBuffer, BUFFER_SIZE, 1, file );
   if( blocksRead != 1 )
   {
     // We read the wrong amount of bytes. Bail.
     fprintf( stderr, "%s: cannot open `%s': Wrong file size.\n", argv[0], argv[2] );
-    return 3;
+    return FILE_SIZE_ERROR;
   }
-  
+
   // Close save file
   fclose( file );
-  
+
   // convert
   int picNum;
   char pixelBuffer[WIDTH*HEIGHT];
-  for( picNum = 1; picNum <= 30; picNum++ )
+  for( picNum = 1; picNum <= 30; ++picNum )
   {
     memset( pixelBuffer, 0x80, WIDTH*HEIGHT*sizeof(pixelBuffer[0]) );
     convert( frameBuffer, saveBuffer, pixelBuffer, picNum );
     writeImageFile( pixelBuffer, picNum );
   }
-  
-  
-  
-  
+
   // Return
-  return 0;
+  return EXIT_SUCCESS;
 }
 
 int picNum2BaseAddress( int picNum )
@@ -121,39 +123,39 @@ int picNum2BaseAddress( int picNum )
   return (picNum + 1) * 0x1000;
 }
 
-void convert( char frameBuffer[static 2*16384], char saveBuffer[static 128*1024], char pixelBuffer[static WIDTH*HEIGHT], int picNum )
+void convert( char frameBuffer[BANK_SIZE * 2], char saveBuffer[BUFFER_SIZE], char pixelBuffer[WIDTH*HEIGHT], int picNum )
 {
   int baseAddress = picNum2BaseAddress( picNum );
   int xTile, yTile, tileAddress, spanAddress, spanNum, tileNum, x, y;
   char lowBits, highBits;
-  for( yTile = 0; yTile < 14; yTile++ ) for( xTile = 0; xTile < 16; xTile++ )
+  for( yTile = 0; yTile < 14; ++yTile ) for( xTile = 0; xTile < 16; ++xTile )
   {
     // for each tile
     tileNum = xTile + yTile * 16;
     tileAddress = baseAddress + tileNum * 16;
 //     printf("\t%x\n", tileAddress );
-    for(spanNum=0; spanNum<8; spanNum++)
+    for(spanNum=0; spanNum<8; ++spanNum)
     {
       // for each span
       spanAddress = tileAddress + spanNum*2;
-      lowBits  = saveBuffer[ spanAddress   ];
-      highBits = saveBuffer[ spanAddress+1 ];
+      lowBits = frameBuffer[spanAddress];
+      highBits = frameBuffer[++spanAddress];
       x = 16 + xTile*8;
       y = 16 + yTile*8 + spanNum;
 //       printf( "tile: %d, x: %d, y: %d\n", tileNum, x, y );
       drawSpan( pixelBuffer, lowBits, highBits, x, y );
     }
   }
-  
+
   // next, apply the frame
   // grab frame number
   char frameNumber = saveBuffer[baseAddress + 0xfb0];
-  
+
   // validate the frame number.
   // return if it's not valid.
   if( frameNumber < 0 || frameNumber >= 18 )
     return;
-  
+
   // calculate the border address.
   // it can be in one of two banks
   int frameAddress = 0;
@@ -161,7 +163,7 @@ void convert( char frameBuffer[static 2*16384], char saveBuffer[static 128*1024]
     frameAddress = frameNumber * 0x688;
   else if( frameNumber < 18 )
     frameAddress = 0x4000 + (frameNumber - 9) * 0x688;
-  
+
   // apply the top of the frame
   // iterate over each tile in the tilemap
   // top row
@@ -170,11 +172,11 @@ void convert( char frameBuffer[static 2*16384], char saveBuffer[static 128*1024]
     tileNum = frameBuffer[frameAddress + 0x600 + xTile];
     tileAddress = frameAddress + tileNum*16;
     // draw the tile
-    for( spanNum = 0; spanNum<8; spanNum++ )
+    for( spanNum = 0; spanNum<8; ++spanNum )
     {
       spanAddress = tileAddress + 2*spanNum;
       lowBits = frameBuffer[spanAddress];
-      highBits = frameBuffer[spanAddress+1];
+      highBits = frameBuffer[++spanAddress];
       x = xTile*8;
       y = 0 + spanNum;
       drawSpan( pixelBuffer, lowBits, highBits, x, y );
@@ -186,11 +188,11 @@ void convert( char frameBuffer[static 2*16384], char saveBuffer[static 128*1024]
     tileNum = frameBuffer[frameAddress + 0x614 + xTile];
     tileAddress = frameAddress + tileNum*16;
     // draw the tile
-    for( spanNum = 0; spanNum<8; spanNum++ )
+    for( spanNum = 0; spanNum<8; ++spanNum )
     {
       spanAddress = tileAddress + 2*spanNum;
       lowBits = frameBuffer[spanAddress];
-      highBits = frameBuffer[spanAddress+1];
+      highBits = frameBuffer[++spanAddress];
       x = xTile*8;
       y = 8 + spanNum;
       drawSpan( pixelBuffer, lowBits, highBits, x, y );
@@ -202,7 +204,7 @@ void convert( char frameBuffer[static 2*16384], char saveBuffer[static 128*1024]
     tileNum = frameBuffer[frameAddress + 0x628 + xTile];
     tileAddress = frameAddress + tileNum*16;
     // draw the tile
-    for( spanNum = 0; spanNum<8; spanNum++ )
+    for( spanNum = 0; spanNum<8; ++spanNum )
     {
       spanAddress = tileAddress + 2*spanNum;
       lowBits = frameBuffer[spanAddress];
@@ -218,19 +220,19 @@ void convert( char frameBuffer[static 2*16384], char saveBuffer[static 128*1024]
     tileNum = frameBuffer[frameAddress + 0x63c + xTile];
     tileAddress = frameAddress + tileNum*16;
     // draw the tile
-    for( spanNum = 0; spanNum<8; spanNum++ )
+    for( spanNum = 0; spanNum<8; ++spanNum )
     {
       spanAddress = tileAddress + 2*spanNum;
       lowBits = frameBuffer[spanAddress];
-      highBits = frameBuffer[spanAddress+1];
+      highBits = frameBuffer[++spanAddress];
       x = xTile*8;
       y = 136 + spanNum;
       drawSpan( pixelBuffer, lowBits, highBits, x, y );
     }
   }
-  
+
   // sides
-  for( yTile = 0; yTile<14; yTile++ )
+  for( yTile = 0; yTile<14; ++yTile )
   {
     // leftmost tile
     tileNum = frameBuffer[frameAddress + 0x650 + yTile*4 + 0];
@@ -240,7 +242,7 @@ void convert( char frameBuffer[static 2*16384], char saveBuffer[static 128*1024]
     {
       spanAddress = tileAddress + 2*spanNum;
       lowBits = frameBuffer[spanAddress];
-      highBits = frameBuffer[spanAddress+1];
+      highBits = frameBuffer[++spanAddress];
       x = 0;
       y = 16 + yTile*8 + spanNum;
       drawSpan( pixelBuffer, lowBits, highBits, x, y );
@@ -249,11 +251,11 @@ void convert( char frameBuffer[static 2*16384], char saveBuffer[static 128*1024]
     tileNum = frameBuffer[frameAddress + 0x650 + yTile*4 + 1];
     tileAddress = frameAddress + tileNum*16;
     // draw the tile
-    for( spanNum = 0; spanNum<8; spanNum++ )
+    for( spanNum = 0; spanNum<8; ++spanNum )
     {
       spanAddress = tileAddress + 2*spanNum;
       lowBits = frameBuffer[spanAddress];
-      highBits = frameBuffer[spanAddress+1];
+      highBits = frameBuffer[++spanAddress];
       x = 8;
       y = 16 + yTile*8 + spanNum;
       drawSpan( pixelBuffer, lowBits, highBits, x, y );
@@ -262,11 +264,11 @@ void convert( char frameBuffer[static 2*16384], char saveBuffer[static 128*1024]
     tileNum = frameBuffer[frameAddress + 0x650 + yTile*4 + 2];
     tileAddress = frameAddress + tileNum*16;
     // draw the tile
-    for( spanNum = 0; spanNum<8; spanNum++ )
+    for( spanNum = 0; spanNum<8; ++spanNum )
     {
       spanAddress = tileAddress + 2*spanNum;
       lowBits = frameBuffer[spanAddress];
-      highBits = frameBuffer[spanAddress+1];
+      highBits = frameBuffer[++spanAddress];
       x = 144;
       y = 16 + yTile*8 + spanNum;
       drawSpan( pixelBuffer, lowBits, highBits, x, y );
@@ -275,11 +277,11 @@ void convert( char frameBuffer[static 2*16384], char saveBuffer[static 128*1024]
     tileNum = frameBuffer[frameAddress + 0x650 + yTile*4 + 3];
     tileAddress = frameAddress + tileNum*16;
     // draw the tile
-    for( spanNum = 0; spanNum<8; spanNum++ )
+    for( spanNum = 0; spanNum<8; ++spanNum )
     {
       spanAddress = tileAddress + 2*spanNum;
       lowBits = frameBuffer[spanAddress];
-      highBits = frameBuffer[spanAddress+1];
+      highBits = frameBuffer[++spanAddress];
       x = 152;
       y = 16 + yTile*8 + spanNum;
       drawSpan( pixelBuffer, lowBits, highBits, x, y );
@@ -287,12 +289,12 @@ void convert( char frameBuffer[static 2*16384], char saveBuffer[static 128*1024]
   }
 }
 
-void drawSpan( char pixelBuffer[static WIDTH*HEIGHT], char lowBits, char highBits, int x, int y )
+void drawSpan( char pixelBuffer[WIDTH*HEIGHT], char lowBits, char highBits, int x, int y )
 {
   int pixelNum;
   char spanColors[8];
   int grays[4] = {0xFF, 0xAA, 0x55, 0x00};
-  for(pixelNum=0; pixelNum<8; pixelNum++)
+  for(pixelNum=0; pixelNum<8; ++pixelNum++)
   {
     int color = 0;
     int mask = 1<<pixelNum;
@@ -302,21 +304,21 @@ void drawSpan( char pixelBuffer[static WIDTH*HEIGHT], char lowBits, char highBit
       color += 2;
     spanColors[7-pixelNum] = grays[ color ];
   }
-  for(pixelNum=0; pixelNum<8; pixelNum++)
+  for(pixelNum=0; pixelNum<8; ++pixelNum)
   {
     // copy span to pixel buffer
-    int pixelAddress = x + 160 * y +pixelNum;
+    int pixelAddress = x + 160 * y + pixelNum;
     pixelBuffer[pixelAddress] = spanColors[pixelNum];
   }
 }
 
-void writeImageFile( char pixelBuffer[static WIDTH*HEIGHT], int picNum )
+void writeImageFile( char pixelBuffer[WIDTH*HEIGHT], int picNum )
 {
   // open file
   char name[50];
   sprintf(name, "%d.png", picNum );
   FILE *fp = fopen( name, "wb" );
-  
+
   png_structp png_ptr = png_create_write_struct
     (PNG_LIBPNG_VER_STRING, NULL, NULL, NULL);
 
@@ -330,23 +332,23 @@ void writeImageFile( char pixelBuffer[static WIDTH*HEIGHT], int picNum )
           (png_infopp)NULL);
       return;
   }
-  
+
     // init output
   png_init_io( png_ptr, fp );
-  
+
   // set header info
-  png_set_IHDR( png_ptr, info_ptr, WIDTH, HEIGHT, 8, 
+  png_set_IHDR( png_ptr, info_ptr, WIDTH, HEIGHT, 8,
                 PNG_COLOR_TYPE_GRAY, PNG_INTERLACE_NONE, PNG_COMPRESSION_TYPE_DEFAULT, PNG_FILTER_TYPE_DEFAULT );
-    
+
   // setup row pointers
   png_bytep * row_pointers = (png_bytep*) malloc(sizeof(png_bytep) * HEIGHT);
   int y;
   for(y=0; y<HEIGHT; ++y)
     row_pointers[y] = (png_byte *)(pixelBuffer + WIDTH * y);
-  
+
   // set rows
   png_set_rows( png_ptr, info_ptr, row_pointers );
-  
+
   // write png
 //  png_write_png( png_ptr, info_ptr, 0, NULL );
   png_write_info(png_ptr, info_ptr);

--- a/gbcamextract.c
+++ b/gbcamextract.c
@@ -38,6 +38,7 @@ const int FILE_ERROR = 2;
 const int FILE_SIZE_ERROR = 3;
 
 const int WIDTH = 160;
+const int ROW_SIZE = WIDTH / 4; // 2 bits per pixel means 4 pixels per byte
 const int HEIGHT = 144;
 const int BUFFER_SIZE = 128*1024;
 
@@ -111,7 +112,7 @@ int main( int argc, char *argv[] )
 
   // convert
   int picNum;
-  char pixelBuffer[WIDTH*HEIGHT];
+  char pixelBuffer[ROW_SIZE*HEIGHT];
   for( picNum = 1; picNum <= 30; ++picNum )
   {
     convert( frameBuffer, saveBuffer, pixelBuffer, picNum );
@@ -188,8 +189,8 @@ void convert( char frameBuffer[], char saveBuffer[], char pixelBuffer[], int pic
 void drawSpan( char pixelBuffer[], char *buffer, int x, int y ) {
   unsigned char lowBits, highBits, i;
   char *p;
-  p = pixelBuffer + (x/4) + 1 + y * (WIDTH/4);
-  for( i = 8; i; --i, p+=(WIDTH/4)+2 )
+  p = pixelBuffer + (x/4) + 1 + y * ROW_SIZE;
+  for( i = 8; i; --i, p+=ROW_SIZE+2 )
   {
     lowBits = ~*buffer++;
     highBits = ~*buffer++;
@@ -232,7 +233,7 @@ void writeImageFile( char pixelBuffer[], int picNum )
   // setup row pointers
   png_bytep * row_pointers = malloc(sizeof(png_bytep) * HEIGHT);
   for(y=0; y<HEIGHT; ++y)
-    row_pointers[y] = (png_byte *)(pixelBuffer + (WIDTH/4) * y);
+    row_pointers[y] = (png_byte *)(pixelBuffer + ROW_SIZE * y);
 
   // set rows
   png_set_rows( png_ptr, info_ptr, row_pointers );

--- a/gbcamextract.c
+++ b/gbcamextract.c
@@ -187,17 +187,17 @@ void convert( char frameBuffer[], char saveBuffer[], char pixelBuffer[], int pic
 }
 
 void drawSpan( char pixelBuffer[], char *buffer, int x, int y ) {
-  unsigned char lowBits, highBits, i;
-  char *p;
-  p = pixelBuffer + (x/4) + 1 + y * ROW_SIZE;
-  for( i = 8; i; --i, p+=ROW_SIZE+2 )
+  unsigned char lowBits, highBits;
+  char *p, *q;
+  p = pixelBuffer + (x/4) + y * ROW_SIZE;
+  for( q = p + ROW_SIZE * 8; p<q; p+=ROW_SIZE )
   {
     lowBits = ~*buffer++;
     highBits = ~*buffer++;
-    *p-- = (lowBits & 1) | ((highBits & 1) << 1) | ((lowBits & 2) << 1) | ((highBits & 2) << 2) | ((lowBits & 4) << 2)  | ((highBits & 4) << 3) | ((lowBits & 8) << 3) | ((highBits & 8) << 4);
+    p[1] = (lowBits & 1) | ((highBits & 1) << 1) | ((lowBits & 2) << 1) | ((highBits & 2) << 2) | ((lowBits & 4) << 2)  | ((highBits & 4) << 3) | ((lowBits & 8) << 3) | ((highBits & 8) << 4);
     lowBits >>= 4;
     highBits >>= 4;
-    *p-- = (lowBits & 1) | ((highBits & 1) << 1) | ((lowBits & 2) << 1) | ((highBits & 2) << 2) | ((lowBits & 4) << 2)  | ((highBits & 4) << 3) | ((lowBits & 8) << 3) | ((highBits & 8) << 4);
+    p[0] = (lowBits & 1) | ((highBits & 1) << 1) | ((lowBits & 2) << 1) | ((highBits & 2) << 2) | ((lowBits & 4) << 2)  | ((highBits & 4) << 3) | ((lowBits & 8) << 3) | ((highBits & 8) << 4);
   }
 }
 


### PR DESCRIPTION
I apologize that this turned into a monster of a pull request. If it would make it easier for you to review, I wouldn't mind breaking it into smaller chunks.

The big change here is outputting an image with a bit depth of 2 instead of 8. The Gameboy Camera only has a bit depth of two, this just reflects that in the output. So, instead of repeating the same 2 bits four times for each pixel to force each pixel to be exactly one byte, we can pack 4 pixels into one byte.

Everything else that I changed was only in service of reducing the amount of duplicated code so that I could more easily wrap my mind around the parts I was working on. If you think it makes the code less readable, it wouldn't be difficult for me to work back in the other direction, especially now that I have the *trick* figured out.